### PR TITLE
(pt-BR) Changed format for weekdays

### DIFF
--- a/js/bootstrap-material-datetimepicker.js
+++ b/js/bootstrap-material-datetimepicker.js
@@ -731,7 +731,7 @@
                  _template += '<table class="table dtp-picker-days"><thead>';
                  for (var i = 0; i < calendar.week.length; i++)
                  {
-                    _template += '<th>' + moment(parseInt(calendar.week[i]), "d").locale(this.params.lang).format("dd").substring(0, 1) + '</th>';
+                    _template += '<th>' + moment(parseInt(calendar.week[i]), "d").locale(this.params.lang).format("ddd").substring(0, 1) + '</th>';
                  }
 
                  _template += '</thead>';


### PR DESCRIPTION
On pt-BR locale, the **'dd'** format picks **weekdaysMin** setting from moment.js, causing this visualization: **D 2 3 4 5 6 S**
Changing to format **'ddd'**, moment.js picks **weekdaysShort** setting, which causes the correct visualization: **D S T Q Q S S**